### PR TITLE
We should firewall rules immediately

### DIFF
--- a/ansible/plays/hub.yml
+++ b/ansible/plays/hub.yml
@@ -50,6 +50,7 @@
       ansible.posix.firewalld:
         service: "{{ item.value.service }}"
         permanent: "{{ item.value.permanent | default('yes') }}"
+        immediate: "{{ item.value.immediate | default('yes') }}"
         state: "{{ item.value.state }}"
         zone: "{{ item.value.zone }}"
       with_dict: "{{ firewalld_service_rules }}"


### PR DESCRIPTION
@trevorcampbell I think you can merge this right away, the change is trivial (but important), I'm just opening the PR for visibility.

This change tells the firewalld module to apply the changes to the currently
running firewall, in addition to making the change on disk. This is necessary
for things like letsencrypt to have access later on without a manual reload of
the firewall rules.