### PR TITLE
Make rudaux installation idempotent

### DIFF
--- a/ansible/roles/internal/rudaux/defaults/main.yml
+++ b/ansible/roles/internal/rudaux/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+# Package name
+rudaux_package: rudaux
+rudaux_repo: git+https://github.com/UBC-DSCI/rudaux
+rudaux_version: 0.5.0
+rudaux_branch: master

--- a/ansible/roles/internal/rudaux/tasks/main.yml
+++ b/ansible/roles/internal/rudaux/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Install rudaux
   pip:
-    name: 'git+https://github.com/ianabc/rudaux'
+    name: "{{ rudaux_repo }}@{{ rudaux_branch }}#{{ rudaux_version }}"
     executable: "{{ python3_pip_executable | default('pip3.9') }}"
 


### PR DESCRIPTION
This PR should allow ansible to determine the installation status for rudaux so that it doesn't spuriously report the check as a change.

Specify the branch and version we want for rudaux so that ansible can verify
the status.

Signed-off-by: Ian Allison <iana@pims.math.ca>