### PR TITLE
Need to allow acme requests over https too

### DIFF
--- a/ansible/roles/internal/dehydrated-letsencrypt/tasks/main.yml
+++ b/ansible/roles/internal/dehydrated-letsencrypt/tasks/main.yml
@@ -71,6 +71,13 @@
 - name: Flush handlers for dehydrate
   meta: flush_handlers
 
+- name: Add nginx location handler for https
+  template:
+    src: acme-nginx.conf.j2
+    dest: "{{ nginx_conf_path }}/https-locations.d/acme-nginx.conf"
+  notify:
+    - reload nginx
+
 - name: Retain a copy of the configuration
   ansible.posix.synchronize:
     src: '{{ acme_home }}'


### PR DESCRIPTION
Once the system is up and running, _all_ requests to http will be redirected to https, including the acme challenges. Just like #18, but now with less pollution!