### PR TITLE
Pin altair to avoid VL bug

### DIFF
--- a/docker/py-dsci-100/Dockerfile
+++ b/docker/py-dsci-100/Dockerfile
@@ -34,7 +34,7 @@ RUN mamba install --quiet --yes \
     && fix-permissions "/home/${NB_USER}" 
 
 # Install some recent python package that might not be on conda yet
-RUN pip install pandas"<2.1" altair">=5.0.1" "vegafusion[embed]" vl-convert-python
+RUN pip install pandas"<2.1" altair"==5.0.1" "vegafusion[embed]" vl-convert-python
 
 # Install nbgitpuller, jlab-git
 RUN pip install nbgitpuller jupyterlab-git \

--- a/docker/py-dsci-100/Dockerfile
+++ b/docker/py-dsci-100/Dockerfile
@@ -34,7 +34,7 @@ RUN mamba install --quiet --yes \
     && fix-permissions "/home/${NB_USER}" 
 
 # Install some recent python package that might not be on conda yet
-RUN pip install pandas"<2.1" altair">=5.1.1" "vegafusion[embed]" vl-convert-python">=0.13"
+RUN pip install pandas"<2.1" altair">=5.0.1" "vegafusion[embed]" vl-convert-python
 
 # Install nbgitpuller, jlab-git
 RUN pip install nbgitpuller jupyterlab-git \


### PR DESCRIPTION
What I reported here https://github.ubc.ca/UBC-DSCI/dsci-100-instructor/pull/827#discussion_r2806 is actually not an issue with vegafusion but with recent version of Vega-Lite, as reported here https://github.com/vega/vega-lite/issues/9078 which affects altair 5.1 and 5.1.1. We could wait for a fix and a new release since the affected worksheet (clustering) is later in the course, but putting this up in case you prefer to downgrade and not touch it later. I don't think we use any of the functionality introduced since altair 5.0.1. We do still need 5.1.1 to build the book, so let's not change that image.

I also unpinned vl-convert; I think 0.13 could work with 5.0.1 but I'm not sure and we only need the 0.13 capabilities for building the pdf version of the book, so might as well remove it here. (this is not the same image as the book, right?)